### PR TITLE
Pull Request: 1-add dbcontext unit tests

### DIFF
--- a/Cinema-Nlayer-MVC.sln
+++ b/Cinema-Nlayer-MVC.sln
@@ -1,13 +1,15 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
-VisualStudioVersion = 17.13.35818.85 d17.13
+VisualStudioVersion = 17.13.35818.85
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cinema.WebApp", "Cinema.WebApp\Cinema.WebApp.csproj", "{AF4DF64F-2E9B-482C-AF8F-07106A0FB07E}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cinema.BLL", "Cinema.BLL\Cinema.BLL.csproj", "{27686E32-3124-43A7-A2A1-ECECDDEAFED9}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cinema.DAL", "Cinema.DAL\Cinema.DAL.csproj", "{3EEA8451-C9ED-4744-9E90-8EAE83FC82DC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cinema.Tests", "Cinema.Tests\Cinema.Tests.csproj", "{2240EB8A-3100-47A9-A8B5-9D7B7DD1C580}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -27,6 +29,10 @@ Global
 		{3EEA8451-C9ED-4744-9E90-8EAE83FC82DC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3EEA8451-C9ED-4744-9E90-8EAE83FC82DC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3EEA8451-C9ED-4744-9E90-8EAE83FC82DC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2240EB8A-3100-47A9-A8B5-9D7B7DD1C580}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2240EB8A-3100-47A9-A8B5-9D7B7DD1C580}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2240EB8A-3100-47A9-A8B5-9D7B7DD1C580}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2240EB8A-3100-47A9-A8B5-9D7B7DD1C580}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Cinema.DAL/Data/CinemaDbContext.cs
+++ b/Cinema.DAL/Data/CinemaDbContext.cs
@@ -2,10 +2,10 @@
 
 namespace Cinema.DAL.Data;
 
-internal class CinemaDbContext : DbContext
+public class CinemaDbContext : DbContext
 {
     public CinemaDbContext(DbContextOptions<CinemaDbContext> options)
-        : base(options)
+        : base(options ?? throw new ArgumentNullException(nameof(options)))
     {
     }
 

--- a/Cinema.Tests/Cinema.Tests.csproj
+++ b/Cinema.Tests/Cinema.Tests.csproj
@@ -1,0 +1,39 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.11" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Folder Include="BLL\DTOs\" />
+    <Folder Include="BLL\Helpers\" />
+    <Folder Include="BLL\Validators\" />
+    <Folder Include="BLL\Services\" />
+    <Folder Include="DAL\Configurations\" />
+    <Folder Include="DAL\Entities\" />
+    <Folder Include="DAL\Repositories\" />
+    <Folder Include="WebApp\Controllers\" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Cinema.DAL\Cinema.DAL.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Cinema.Tests/DAL/Data/CinemaDbContextTests.cs
+++ b/Cinema.Tests/DAL/Data/CinemaDbContextTests.cs
@@ -1,0 +1,24 @@
+﻿using Cinema.DAL.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Cinema.Tests.DAL.Data;
+public class CinemaDbContextTests
+{
+    [Fact]
+    public void CanCreateCinemaDbContext_WhenOptionsProvided_ShouldNotBeNull()
+    {
+        var options = new DbContextOptionsBuilder<CinemaDbContext>()
+            .UseInMemoryDatabase("TestDb")
+            .Options;
+
+        using var dbContext = new CinemaDbContext(options);
+
+        Assert.NotNull(dbContext);
+    }
+
+    [Fact]
+    public void CanCreateCinemaDbContext_WhenOptionsNotProvided_ShouldThrowArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new CinemaDbContext(null!));
+    }
+}


### PR DESCRIPTION
## ✨ What’s New?
- Added unit tests for `CinemaDbContext`.
- Implemented a `null` check in the `CinemaDbContext` constructor to throw `ArgumentNullException`.

## 🛠 Changes
- Created `CinemaDbContextTests` in the test project.
- Added tests for:
  - Successful `CinemaDbContext` creation.
  - Ensuring `ArgumentNullException` is thrown when `null` options are passed.
- Updated `CinemaDbContext` constructor to explicitly handle `null`.

## ✅ How to Test?
1. Run the unit tests using xUnit.
2. Ensure all tests pass successfully.

## 🔗 Related Issue
Closes #1
