### PR TITLE
Pull Request: 6-Introduce Repository Pattern (Interface + Implementation)

### DIFF
--- a/Cinema.DAL/Interfaces/Repositories/IRepository.cs
+++ b/Cinema.DAL/Interfaces/Repositories/IRepository.cs
@@ -1,0 +1,16 @@
+﻿using Ardalis.Specification;
+using System.Linq.Expressions;
+
+namespace Cinema.DAL.Interfaces.Repositories;
+
+public interface IRepository<TEntity> where TEntity : class, IEntity
+{
+    IQueryable<TEntity> GetAll();
+    TEntity? GetById(int id);
+    void Insert(TEntity entity);
+    void Update(TEntity entity);
+    void Delete(int id);
+    void Delete(TEntity entity);
+
+    IQueryable<TEntity> Find(Expression<Func<TEntity, bool>> predicate);
+}

--- a/Cinema.DAL/Repositories/Repository.cs
+++ b/Cinema.DAL/Repositories/Repository.cs
@@ -1,0 +1,65 @@
+﻿using Cinema.DAL.Interfaces;
+using Microsoft.EntityFrameworkCore;
+using System.Linq.Expressions;
+using Cinema.DAL.Interfaces.Repositories;
+
+namespace Cinema.DAL.Repositories;
+
+public class Repository<TEntity> : IRepository<TEntity> where TEntity : class, IEntity
+{
+    private readonly DbContext _context;
+    private readonly DbSet<TEntity> _dbSet;
+
+    public Repository(DbContext context)
+    {
+        _context = context;
+        _dbSet = _context.Set<TEntity>();
+    }
+
+    public IQueryable<TEntity> GetAll()
+    {
+        return _dbSet.AsQueryable();
+    }
+
+    public TEntity? GetById(int id)
+    {
+        return _dbSet.Find(id);
+    }
+
+    public void Insert(TEntity entity)
+    {
+        _dbSet.Add(entity);
+    }
+
+    public void Update(TEntity entity)
+    {
+        if (_context.Entry(entity).State == EntityState.Detached)
+        {
+            _dbSet.Attach(entity);
+        }
+        _context.Entry(entity).State = EntityState.Modified;
+    }
+
+    public void Delete(int id)
+    {
+        var entity = _dbSet.Find(id);
+        if (entity != null)
+        {
+            Delete(entity);
+        }
+    }
+
+    public void Delete(TEntity entity)
+    {
+        if (_context.Entry(entity).State == EntityState.Detached)
+        {
+            _dbSet.Attach(entity);
+        }
+        _dbSet.Remove(entity);
+    }
+
+    public IQueryable<TEntity> Find(Expression<Func<TEntity, bool>> predicate)
+    {
+        return _dbSet.Where(predicate);
+    }
+}


### PR DESCRIPTION
# PR: Introduce Repository Pattern (Interface + Implementation)

## Summary

This pull request adds a **Repository Pattern** to our codebase, providing a clean abstraction layer for data access. It includes the `IRepository<TEntity>` interface and a corresponding generic implementation, paving the way for more maintainable and testable code.

## What's Changed

- **New Interface**  
  - `IRepository<TEntity>` defining common CRUD methods (`GetAll`, `GetById`, `Insert`, `Update`, `Delete`) and a `Find` method for custom queries.

- **Generic Repository Class**  
  - Implements `IRepository<TEntity>` using Entity Framework Core.
  - Encapsulates standard data access operations, reducing boilerplate code.
  - Does **not** call `SaveChanges()`; this logic is delegated to a higher-level component (e.g., `UnitOfWork` or application services).

## Motivation

1. **Clean Architecture**: By hiding EF Core details behind a repository abstraction, the rest of the application remains decoupled from persistence concerns.
2. **Easier Testing**: Repositories can be mocked or replaced with in-memory implementations, simplifying unit and integration tests.
3. **Future Flexibility**: If we ever switch from EF Core or alter our data storage strategy, we can do so without impacting the broader codebase.

## Implementation Details

- **Generic Approach**  
  Uses `DbSet<TEntity>` internally to handle CRUD operations, ensuring minimal duplication.
  
- **Separation of Concerns**  
  The repository focuses solely on data retrieval/manipulation, leaving transaction management (`SaveChanges()`) to a higher-level pattern or service.

- **Queryable Returns**  
  Methods like `GetAll()` and `Find(...)` return `IQueryable<TEntity>` for flexible filtering and ordering.

## Testing

- Basic CRUD operations were manually verified.
- Confirmed that `Insert`, `Update`, `Delete`, `GetById`, and `GetAll` perform as expected in a demo environment.

## Future Improvements

- **Unit of Work**: A dedicated `UnitOfWork` class will eventually handle transactions and coordinate multiple repositories.
- **Specification Pattern**: Complex queries, includes, and filtering could be encapsulated in specifications.
- **Cross-Cutting Concerns**: Potential integration of caching, logging, or auditing at the repository level in the future.

---

Merging this PR lays the groundwork for a more robust and modular data access layer. Feedback and suggestions are highly welcome!

#6