### PR TITLE
Pull Request: 36-Update AutoMapper Profiles for CreateDto and UpdateDto

### DIFF
--- a/Cinema.BLL/Helpers/GenreProfile.cs
+++ b/Cinema.BLL/Helpers/GenreProfile.cs
@@ -9,7 +9,9 @@ public class GenreProfile : Profile
     public GenreProfile()
     {
         CreateMap<Genre, GenreDto>();
-
         CreateMap<Genre, GenreDetailsDto>();
+
+        CreateMap<GenreCreateDto, Genre>();
+        CreateMap<GenreUpdateDto, Genre>();
     }
 }

--- a/Cinema.BLL/Helpers/MovieProfile.cs
+++ b/Cinema.BLL/Helpers/MovieProfile.cs
@@ -9,7 +9,9 @@ public class MovieProfile : Profile
     public MovieProfile()
     {
         CreateMap<Movie, MovieDto>();
-
         CreateMap<Movie, MovieDetailsDto>();
+
+        CreateMap<MovieCreateDto, Movie>();
+        CreateMap<MovieUpdateDto, Movie>();
     }
 }

--- a/Cinema.BLL/Helpers/PaymentProfile.cs
+++ b/Cinema.BLL/Helpers/PaymentProfile.cs
@@ -9,7 +9,9 @@ public class PaymentProfile : Profile
     public PaymentProfile()
     {
         CreateMap<Payment, PaymentDto>();
-
         CreateMap<Payment, PaymentDetailsDto>();
+
+        CreateMap<PaymentCreateDto, Payment>();
+        CreateMap<PaymentUpdateDto, Payment>();
     }
 }

--- a/Cinema.BLL/Helpers/SeatProfile.cs
+++ b/Cinema.BLL/Helpers/SeatProfile.cs
@@ -9,7 +9,9 @@ public class SeatProfile : Profile
     public SeatProfile()
     {
         CreateMap<Seat, SeatDto>();
-
         CreateMap<Seat, SeatDetailsDto>();
+
+        CreateMap<SeatCreateDto, Seat>();
+        CreateMap<SeatUpdateDto, Seat>();
     }
 }

--- a/Cinema.BLL/Helpers/SessionProfile.cs
+++ b/Cinema.BLL/Helpers/SessionProfile.cs
@@ -9,9 +9,10 @@ public class SessionProfile : Profile
     public SessionProfile()
     {
         CreateMap<Session, SessionDto>();
-
         CreateMap<Session, SessionDetailsWithoutTicketsDto>();
-
         CreateMap<Session, SessionDetailsWithTicketsDto>();
+
+        CreateMap<SessionCreateDto, Session>();
+        CreateMap<SessionUpdateDto, Session>();
     }
 }

--- a/Cinema.BLL/Helpers/TicketProfile.cs
+++ b/Cinema.BLL/Helpers/TicketProfile.cs
@@ -9,7 +9,12 @@ public class TicketProfile : Profile
     public TicketProfile()
     {
         CreateMap<Ticket, TicketDto>();
-
         CreateMap<Ticket, TicketDetailsDto>();
+
+        CreateMap<TicketCreateDto, Ticket>()
+            .ForMember(dest => dest.TicketNumber, opt => opt.Ignore());
+
+        CreateMap<TicketUpdateDto, Ticket>()
+            .ForMember(dest => dest.TicketNumber, opt => opt.Ignore());
     }
 }


### PR DESCRIPTION
## Update AutoMapper Profiles for `CreateDto` and `UpdateDto`

### Overview
This PR updates the AutoMapper configuration to include mappings for the newly introduced `CreateDto` and `UpdateDto` classes across the application. These mappings ensure proper transformation between DTOs and domain entities during create and update operations.

### Changes
- Added mappings from `CreateDto` → Domain Entity.
- Added mappings from `UpdateDto` → Domain Entity.
- Updated existing AutoMapper profiles to include the new mappings.
- Applied `.ForMember()` configurations where custom mapping was needed (if any).

### Motivation
These changes are required to:
- Enable clean and consistent mapping between layers.
- Avoid manual field assignment in services or controllers.
- Support the new DTO structure introduced in previous updates.

### Notes
- All mappings were added following existing profile structure.
- Reverse mappings were not included unless specifically required.
- No breaking changes introduced.

Let me know if you'd like any specific mappings reviewed!
